### PR TITLE
Fix: price impact and pool share calculation

### DIFF
--- a/src/components/ConfirmSwapModal.vue
+++ b/src/components/ConfirmSwapModal.vue
@@ -44,7 +44,7 @@
         <span>{{ slippage }}%</span>
       </div>
       <div v-if="!isAeVsWae">
-        <span>{{ $t('confirmSwapModal.priceImpact') }}</span>
+        <span>{{ $t('confirmSwapModal.priceImpact', { token: from.symbol }) }}</span>
         <span>{{ priceImpact?.toFixed(8) }}%</span>
       </div>
       <div class="no-border">

--- a/src/lib/swapUtils.js
+++ b/src/lib/swapUtils.js
@@ -119,7 +119,7 @@ const getPriceImpactForPairReserves = (pairReserves, amountA) => {
   const marketPrice = BigNumber(1).div(ratioFromPairReserves(pairReserves));
   const newPrice = BigNumber(amountA).div(receivedB);
 
-  return newPrice.minus(marketPrice).times(100).div(marketPrice).toNumber();
+  return -newPrice.minus(marketPrice).times(100).div(newPrice).toNumber();
 };
 
 /**

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -50,7 +50,7 @@
     "to": "To",
     "transactionDetails": "Transaction Details",
     "liquidityProviderFee": "Liquidity Provider Fee",
-    "priceImpact": "Price Impact",
+    "priceImpact": "Price Impact on {token}",
     "allowedSlippage": "Allowed Slippage",
     "minReceived": "Minimum received",
     "maxSpent": "Maximum spent",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -42,7 +42,7 @@
     "to": "Pour",
     "transactionDetails": "détails de la transaction",
     "liquidityProviderFee": "Frais de fournisseur de liquidité",
-    "priceImpact": "Incidence sur les prix",
+    "priceImpact": "Incidence sur les prix de {token}",
     "allowedSlippage": "Glissement autorisé",
     "minReceived": "Minimum reçu",
     "maxSpent": "Dépense maximale",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -36,7 +36,7 @@
     "to": "Получаете",
     "transactionDetails": "Детали транзакции",
     "liquidityProviderFee": "Комиссия поставщика ликвидности",
-    "priceImpact": "Влияние на цену",
+    "priceImpact": "Влияние на цену {token}",
     "allowedSlippage": "Допустимое проскальзывание",
     "minReceived": "Минимум к получению",
     "maxSpent": "Максимум к продаже",

--- a/src/locales/zh-cn.json
+++ b/src/locales/zh-cn.json
@@ -49,7 +49,7 @@
     "to": "到",
     "transactionDetails": "交换详情",
     "liquidityProviderFee": "Liquidity Provider Fee",
-    "priceImpact": "价格影响",
+    "priceImpact": "价格影响针对 {token}",
     "allowedSlippage": "滑点",
     "minReceived": "最小收益",
     "maxSpent": "最多支付",

--- a/src/views/AddLiquidity.vue
+++ b/src/views/AddLiquidity.vue
@@ -153,7 +153,10 @@ export default {
       const amountTokenB = expandDecimals(this.amountTokenB, this.tokenB.decimals);
       const amount = amountTokenA * amountTokenB;
       const reserve = this.reserveTokenB * this.reserveTokenA;
-      return BigNumber(amount).times(100).div(reserve).toNumber();
+      return BigNumber(amount)
+        .times(100)
+        .div(reserve + amount)
+        .toNumber();
     },
     ratio() {
       if (!this.reserveTokenA || !this.reserveTokenB || !this.tokenA || !this.tokenB) {

--- a/tests/unit/swap-utils.spec.js
+++ b/tests/unit/swap-utils.spec.js
@@ -70,7 +70,7 @@ describe('route price impact', () => {
   });
   const toPairs = (xs) => xs.map(toPair);
   const priceImpact = (xs, tokenA, amountA) => getPriceImpactForRoute(toPairs(xs), tokenA, amountA);
-  it('price impact to be 0.5', () => {
+  it('price impact to be -0.4975124378109453', () => {
     expect(
       priceImpact(
         [
@@ -82,9 +82,9 @@ describe('route price impact', () => {
         'a',
         10000n,
       ),
-    ).toBe(0.5);
+    ).toBe(-0.4975124378109453);
   });
-  it('price impact to be 5', () => {
+  it('price impact to be -4.761904761904762', () => {
     expect(
       priceImpact(
         [
@@ -96,7 +96,7 @@ describe('route price impact', () => {
         'a',
         100000n,
       ),
-    ).toBe(5);
+    ).toBe(-4.761904761904762);
   });
   it('should receive 1', () => {
     expect(getReceivedTokensForPairReserves([[2, 2]], 2).toNumber()).toBe(1);
@@ -113,7 +113,7 @@ describe('route price impact', () => {
     ).toBe(0.6666666666666666);
   });
 
-  it('swapping reserveA will have priceImpact=100%', () => {
+  it('swapping reserveA will have priceImpact=-50%', () => {
     expect(
       priceImpact(
         [
@@ -125,10 +125,10 @@ describe('route price impact', () => {
         'a',
         2,
       ),
-    ).toBe(100);
+    ).toBe(-50);
   });
 
-  it('swapping reserveA withing two pairs will have priceImpact=200%', () => {
+  it('swapping reserveA withing two pairs will have priceImpact=-66.66666666666667%', () => {
     expect(
       priceImpact(
         [
@@ -144,9 +144,9 @@ describe('route price impact', () => {
         'a',
         2,
       ),
-    ).toBe(200);
+    ).toBe(-66.66666666666667);
   });
-  it('swapping reserveA withing 3 pairs will have priceImpact=300%', () => {
+  it('swapping reserveA withing 3 pairs will have priceImpact=-75%', () => {
     expect(
       priceImpact(
         [
@@ -166,9 +166,9 @@ describe('route price impact', () => {
         'a',
         2,
       ),
-    ).toBe(300);
+    ).toBe(-75);
   });
-  it('swapping 25 for [[100,50],[25,25]] will have priceImpact=75%', () => {
+  it('swapping 25 for [[100,50],[25,25]] will have priceImpact=-42.857142857142854%', () => {
     expect(
       priceImpact(
         [
@@ -184,7 +184,7 @@ describe('route price impact', () => {
         'a',
         25,
       ),
-    ).toBe(75);
+    ).toBe(-42.857142857142854);
   });
 });
 describe('get route reserves', () => {


### PR DESCRIPTION
- Fixed calculation of pool share percentage on AddLiquidity
- Improve calculation and displayment of price impact on Swap
- ℹ️ Translations for adjusted text by ChatGPT, verified with google translate