### PR TITLE
fix: increase timeout of e2e tests

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -13,4 +13,5 @@ export default defineConfig({
     'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4.1 Mobile/15E148 Safari/604.1',
   viewportHeight: 800,
   viewportWidth: 400,
+  defaultCommandTimeout: 20000,
 });


### PR DESCRIPTION
e2e tests keep timing out. This is a workaround, let's see if it helps.